### PR TITLE
Added DIA Aggregator Oracle Contract superOETH-USD on Base

### DIFF
--- a/contracts/diadata/DiaDataAggregator.sol
+++ b/contracts/diadata/DiaDataAggregator.sol
@@ -1,0 +1,69 @@
+    // SPDX-License-Identifier: GPL-3.0
+
+    // ███████╗███████╗██████╗  ██████╗
+    // ╚══███╔╝██╔════╝██╔══██╗██╔═══██╗
+    //   ███╔╝ █████╗  ██████╔╝██║   ██║
+    //  ███╔╝  ██╔══╝  ██╔══██╗██║   ██║
+    // ███████╗███████╗██║  ██║╚██████╔╝
+    // ╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝
+
+    // Website: https://zerolend.xyz
+    // Discord: https://discord.gg/zerolend
+    // Twitter: https://twitter.com/zerolendxyz
+
+    pragma solidity ^0.8.12;
+
+    import {IDiaData} from "../interfaces/IDiaData.sol";
+    import {IAggregatorInterface} from "../interfaces/IAggregatorInterface.sol";
+
+    /**
+     * @title DiaDataAggregator
+     * @notice Aggregator contract for fetching data from the DiaData oracle.
+     * @dev Implements the `IAggregatorInterface` to provide standardized access to the DiaData oracle.
+     */
+    contract DiaDataAggregator is IAggregatorInterface {
+        /// @notice Address of the DiaData consumer contract.
+        IDiaData public consumer;
+
+        /// @notice Default key to fetch data from the DiaData oracle.
+        string public defaultKey;
+
+        /**
+         * @notice Constructor to initialize the DiaDataAggregator contract.
+         * @param _consumer Address of the DiaData consumer contract.
+         * @param _defaultKey Default key to fetch data from the oracle.
+         */
+        constructor(address _consumer, string memory _defaultKey) {
+            consumer = IDiaData(_consumer);
+            defaultKey = _defaultKey;
+        }
+
+        /**
+         * @notice Returns the number of decimals used by the aggregator.
+         * @dev Overrides the `decimals` function of the `IAggregatorInterface`.
+         * @return uint8 The number of decimals (fixed to 8).
+         */
+        function decimals() external pure override returns (uint8) {
+            return 8;
+        }
+
+        /**
+         * @notice Retrieves the latest answer from the DiaData oracle.
+         * @dev Fetches the value corresponding to the `defaultKey` from the DiaData consumer.
+         * @return int256 The latest answer as an integer.
+         */
+        function latestAnswer() external view override returns (int256) {
+            (uint128 value, ) = consumer.getValue(defaultKey);
+            return int256(uint256(value));
+        }
+
+        /**
+         * @notice Retrieves the latest timestamp from the DiaData oracle.
+         * @dev Fetches the timestamp corresponding to the `defaultKey` from the DiaData consumer.
+         * @return uint256 The latest timestamp as a Unix epoch time.
+         */
+        function latestTimestamp() external view returns (uint256) {
+            (, uint128 timestamp) = consumer.getValue(defaultKey);
+            return uint256(timestamp);
+        }
+    }

--- a/contracts/interfaces/IDiaData.sol
+++ b/contracts/interfaces/IDiaData.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+
+// ███████╗███████╗██████╗  ██████╗
+// ╚══███╔╝██╔════╝██╔══██╗██╔═══██╗
+//   ███╔╝ █████╗  ██████╔╝██║   ██║
+//  ███╔╝  ██╔══╝  ██╔══██╗██║   ██║
+// ███████╗███████╗██║  ██║╚██████╔╝
+// ╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝
+
+// Website: https://zerolend.xyz
+// Discord: https://discord.gg/zerolend
+// Twitter: https://twitter.com/zerolendxyz
+
+pragma solidity ^0.8.12;
+
+interface IDiaData {
+    function getValue(string memory key) external view returns (uint128, uint128);
+}


### PR DESCRIPTION
This PR contain the Oracle development contract `DiaAggregator.sol` which uses DIA contract to fetch the price using the function `getValues()` by passing the `key` for example it can be `SUPEROETHB/USD` to get the price. 